### PR TITLE
Add a few new features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@
 
 # rspec failure tracking
 .rspec_status
-coverage

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,25 @@
+AllCops:
+  # Wait until the community has decided
+  NewCops: disable
+
+# These files naturally have long blocks
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*.rb'
+    - '*.gemspec'
+
+# Avoid Cops with arbitrary settings
+Metrics/MethodLength:
+  Enabled: false
+
+# This is no longer upcoming for Ruby
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+# Avoid Cops with arbitrary settings
+Layout/LineLength:
+  Enabled: false
+
+# Avoid comments unless they add value
+Style/Documentation:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ before_script:
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
 script:
-  - bundle exec rspec
+  - bundle exec rake
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in i18n-coverage.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ GEM
   specs:
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    ast (2.4.0)
     builder (3.2.3)
     concurrent-ruby (1.1.5)
     descendants_tracker (0.0.4)
@@ -27,6 +28,7 @@ GEM
     highline (2.0.2)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    jaro_winkler (1.5.4)
     json (2.2.0)
     juwelier (2.4.9)
       builder
@@ -55,11 +57,16 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
+    parallel (1.19.1)
+    parser (2.7.1.2)
+      ast (~> 2.4.0)
     psych (3.1.0)
     public_suffix (3.1.0)
     rack (2.2.2)
+    rainbow (3.0.0)
     rake (13.0.1)
     rdoc (6.1.1)
+    rexml (3.2.4)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -73,6 +80,15 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
+    rubocop (0.82.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.7.0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      rexml
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    ruby-progressbar (1.10.1)
     semver2 (3.4.2)
     simplecov (0.16.1)
       docile (~> 1.1)
@@ -80,6 +96,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     thread_safe (0.3.6)
+    unicode-display_width (1.7.0)
 
 PLATFORMS
   ruby
@@ -91,6 +108,7 @@ DEPENDENCIES
   juwelier (~> 2.4)
   rake (~> 13.0)
   rspec (~> 3.0)
+  rubocop (~> 0.82)
   simplecov
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -17,33 +17,42 @@ gem 'i18n-coverage'
 
 ## Usage
 
-First, you need to ensure that the gem is correctly loaded when running the tests. When using rspec for example:
+Add the following lines somewhere to your test setup. For RSpec, this will be at the top of `spec_helper.rb`.
+
+```ruby
+require 'i18n/coverage'
+I18n::Coverage.start
+```
+
+If you don't want to check I18n Coverage in every test run, you could enable it with an environment variable.
 
 ```ruby
 # file spec_helper.rb
 require 'i18n/coverage'
+I18n::Coverage.start if ENV['I18N_COVERAGE']
 ```
-
-You also need to output/read the results of the coverage. This should be done once all the tests have been executed. Once again, an example with rspec:
-
-```ruby
-RSpec.configure do |config|
-  config.after(:suite) do
-    I18n::Coverage::Reporter.report if ENV['I18N_COVERAGE']
-  end
-end
-```
-
-Then, when running the tests, you need to enable coverage by setting the environment variable `I18N_COVERAGE`. For example with rspec:
 
 ```shell
 I18N_COVERAGE=1 bundle exec rspec
 ```
 
+## Configuration
+
+The default config is [here](lib/i18n/coverage/config.rb).
+
+### Printer
+
+By default the coverage is output to the console. You can also select a different printer, or write your own!
+
+```ruby
+require 'i18n/coverage/printers/file_printer'
+I18n::Coverage.config.printer = I18n::Coverage::Printer::FilePrinter
+I18n::Coverage.start
+```
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests, or just `rake` to run all tasks, such as linting. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
+RuboCop::RakeTask.new
 
-task :default => :spec
+task default: %i[spec rubocop]

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
-require "bundler/setup"
-require "i18n/coverage"
+require 'bundler/setup'
+require 'i18n/coverage'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
@@ -10,5 +10,5 @@ require "i18n/coverage"
 # require "pry"
 # Pry.start
 
-require "irb"
+require 'irb'
 IRB.start(__FILE__)

--- a/i18n-coverage.gemspec
+++ b/i18n-coverage.gemspec
@@ -1,42 +1,41 @@
-
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "i18n/coverage/version"
+require 'i18n/coverage/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "i18n-coverage"
+  spec.name          = 'i18n-coverage'
   spec.version       = I18n::Coverage::VERSION
-  spec.authors       = ["Hiptest"]
-  spec.email         = ["contact@hiptest.com"]
+  spec.authors       = ['Hiptest']
+  spec.email         = ['contact@hiptest.com']
 
-  spec.summary       = %q{Provides a coverage of I18n keys used during test suite}
-  spec.homepage      = "https://github.com/hiptest/i18n-coverage"
+  spec.summary       = 'Provides a coverage of I18n keys used during test suite'
+  spec.homepage      = 'https://github.com/hiptest/i18n-coverage'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata["homepage_uri"] = spec.homepage
-    spec.metadata["source_code_uri"] = "https://github.com/hiptest/i18n-coverage"
-    spec.metadata["changelog_uri"] = "https://github.com/hiptest/i18n-coverage/blob/master/CHANGELOG.md"
+    spec.metadata['homepage_uri'] = spec.homepage
+    spec.metadata['source_code_uri'] = 'https://github.com/hiptest/i18n-coverage'
+    spec.metadata['changelog_uri'] = 'https://github.com/hiptest/i18n-coverage/blob/master/CHANGELOG.md'
   else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
+    raise 'RubyGems 2.0 or newer is required to protect against ' \
+      'public gem pushes.'
   end
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "i18n", "~> 0.7"
-  spec.add_development_dependency "bundler", "~> 1.17"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "juwelier", "~> 2.4"
-  spec.add_development_dependency "simplecov"
-
+  spec.add_development_dependency 'bundler', '~> 1.17'
+  spec.add_development_dependency 'i18n', '~> 0.7'
+  spec.add_development_dependency 'juwelier', '~> 2.4'
+  spec.add_development_dependency 'rake', '~> 13.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rubocop', '~> 0.82'
+  spec.add_development_dependency 'simplecov'
 end

--- a/lib/i18n/coverage.rb
+++ b/lib/i18n/coverage.rb
@@ -5,7 +5,14 @@ require "i18n/backend/key_logger"
 
 module I18n
   module Coverage
+    def self.start
+      I18n::Backend::Simple.send(:include, I18n::Backend::KeyLogger)
+      at_exit { I18n::Coverage::Reporter.report }
+    end
   end
 end
 
-I18n::Backend::Simple.send(:include, I18n::Backend::KeyLogger) if ENV['I18N_COVERAGE']
+if ENV['I18N_COVERAGE']
+  warn "DEPRECATED: use I18n::Coverage.start instead"
+  I18n::Backend::Simple.send(:include, I18n::Backend::KeyLogger)
+end

--- a/lib/i18n/coverage.rb
+++ b/lib/i18n/coverage.rb
@@ -2,12 +2,22 @@ require "i18n"
 require "i18n/coverage/version"
 require "i18n/coverage/reporter"
 require "i18n/backend/key_logger"
+require "i18n/coverage/config"
 
 module I18n
   module Coverage
     def self.start
       I18n::Backend::Simple.send(:include, I18n::Backend::KeyLogger)
       at_exit { I18n::Coverage::Reporter.report }
+    end
+
+    def self.config
+      @config ||= Config.new
+    end
+
+    def self.configure
+      @config = Config.new
+      yield @config if block_given?
     end
   end
 end

--- a/lib/i18n/coverage.rb
+++ b/lib/i18n/coverage.rb
@@ -1,13 +1,13 @@
-require "i18n"
-require "i18n/coverage/version"
-require "i18n/coverage/reporter"
-require "i18n/backend/key_logger"
-require "i18n/coverage/config"
+require 'i18n'
+require 'i18n/coverage/version'
+require 'i18n/coverage/reporter'
+require 'i18n/backend/key_logger'
+require 'i18n/coverage/config'
 
 module I18n
   module Coverage
     def self.start
-      I18n::Backend::Simple.send(:include, I18n::Backend::KeyLogger)
+      I18n::Backend::Simple.include I18n::Backend::KeyLogger
       at_exit { I18n::Coverage::Reporter.report }
     end
 
@@ -23,6 +23,6 @@ module I18n
 end
 
 if ENV['I18N_COVERAGE']
-  warn "DEPRECATED: use I18n::Coverage.start instead"
-  I18n::Backend::Simple.send(:include, I18n::Backend::KeyLogger)
+  warn 'DEPRECATED: use I18n::Coverage.start instead'
+  I18n::Backend::Simple.include I18n::Backend::KeyLogger
 end

--- a/lib/i18n/coverage/config.rb
+++ b/lib/i18n/coverage/config.rb
@@ -1,12 +1,16 @@
+require 'i18n/coverage/printers/basic_printer'
+
 module I18n
   module Coverage
     class Config
       attr_accessor :locale,
-                    :locale_dir_path
+                    :locale_dir_path,
+                    :printer
 
       def initialize
         self.locale = "en"
         self.locale_dir_path = "config/locales"
+        self.printer = I18n::Coverage::Printers::BasicPrinter
       end
     end
   end

--- a/lib/i18n/coverage/config.rb
+++ b/lib/i18n/coverage/config.rb
@@ -1,0 +1,13 @@
+module I18n
+  module Coverage
+    class Config
+      attr_accessor :locale,
+                    :locale_dir_path
+
+      def initialize
+        self.locale = "en"
+        self.locale_dir_path = "config/locales"
+      end
+    end
+  end
+end

--- a/lib/i18n/coverage/config.rb
+++ b/lib/i18n/coverage/config.rb
@@ -8,8 +8,8 @@ module I18n
                     :printer
 
       def initialize
-        self.locale = "en"
-        self.locale_dir_path = "config/locales"
+        self.locale = 'en'
+        self.locale_dir_path = 'config/locales'
         self.printer = I18n::Coverage::Printers::BasicPrinter
       end
     end

--- a/lib/i18n/coverage/key_lister.rb
+++ b/lib/i18n/coverage/key_lister.rb
@@ -3,12 +3,12 @@ require 'yaml'
 module I18n
   module Coverage
     class KeyLister
-      def self.list_keys(locale: 'en', locale_dir_path: 'config/locales')
-        KeyLister.new(locale, locale_dir_path).list_keys
+      def self.list_keys
+        KeyLister.new.list_keys
       end
 
-      def initialize(locale, locale_dir_path)
-        @locale = locale
+      def initialize
+        locale_dir_path = I18n::Coverage.config.locale_dir_path
         @locale_files = Dir.glob("#{locale_dir_path}/**/*.yml")
         @keys = Set[]
       end
@@ -24,7 +24,7 @@ module I18n
       private
 
       def visit_childs(source:, path: )
-        node = source.dig(@locale, *path)
+        node = source.dig(locale, *path)
 
         if node.respond_to? :keys
           keys = node.keys
@@ -41,6 +41,10 @@ module I18n
 
       def pluralization_keys?(keys)
         return (keys - ['zero', 'one', 'other']).empty?
+      end
+
+      def locale
+        I18n::Coverage.config.locale
       end
     end
   end

--- a/lib/i18n/coverage/key_lister.rb
+++ b/lib/i18n/coverage/key_lister.rb
@@ -6,20 +6,20 @@ module I18n
       def self.list_keys(locale: 'en', locale_dir_path: 'config/locales')
         KeyLister.new(locale, locale_dir_path).list_keys
       end
-  
+
       def initialize(locale, locale_dir_path)
         @locale = locale
         @source = YAML.load(File.open(File.expand_path("#{locale_dir_path}/#{locale}.yml")))
         @keys = Set[]
       end
-  
+
       def list_keys
         visit_childs(path: [])
         @keys
       end
-  
+
       private
-  
+
       def visit_childs(path: )
         node = @source.dig(*[@locale, path].flatten.compact)
         if node.respond_to? :keys

--- a/lib/i18n/coverage/key_lister.rb
+++ b/lib/i18n/coverage/key_lister.rb
@@ -34,7 +34,7 @@ module I18n
           else
             keys.map { |key| visit_childs(source: source, path: path + [key]) }
           end
-        elsif path.count > 0
+        elsif path.count.positive?
           @keys.add(path.join('.'))
         end
       end

--- a/lib/i18n/coverage/key_lister.rb
+++ b/lib/i18n/coverage/key_lister.rb
@@ -23,7 +23,7 @@ module I18n
 
       private
 
-      def visit_childs(source:, path: )
+      def visit_childs(source:, path:)
         node = source.dig(locale, *path)
 
         if node.respond_to? :keys
@@ -32,7 +32,7 @@ module I18n
           if pluralization_keys?(keys)
             @keys.add(path.join('.'))
           else
-            keys.map {|key| visit_childs(source: source, path: path + [key])}
+            keys.map { |key| visit_childs(source: source, path: path + [key]) }
           end
         elsif path.count > 0
           @keys.add(path.join('.'))
@@ -40,7 +40,7 @@ module I18n
       end
 
       def pluralization_keys?(keys)
-        return (keys - ['zero', 'one', 'other']).empty?
+        (keys - %w[zero one other]).empty?
       end
 
       def locale

--- a/lib/i18n/coverage/key_logger.rb
+++ b/lib/i18n/coverage/key_logger.rb
@@ -2,27 +2,15 @@ module I18n
   module Coverage
     class KeyLogger
       def self.store_key(key)
-        KeyLogger.new.store_key(key)
-      end
-
-      def self.stored_keys
-        KeyLogger.new.stored_keys
-      end
-
-      def self.clear_keys
-        KeyLogger.new.clear_keys
-      end
-
-      def store_key(key)
         stored_keys.add(key)
       end
 
-      def clear_keys
-        stored_keys.clear
+      def self.stored_keys
+        @stored_keys ||= Set[]
       end
 
-      def stored_keys
-        @@stored_keys ||= Set[]
+      def self.clear_keys
+        stored_keys.clear
       end
     end
   end

--- a/lib/i18n/coverage/key_logger.rb
+++ b/lib/i18n/coverage/key_logger.rb
@@ -18,7 +18,7 @@ module I18n
       end
 
       def clear_keys
-        stored_keys.clear        
+        stored_keys.clear
       end
 
       def stored_keys

--- a/lib/i18n/coverage/printers/basic_printer.rb
+++ b/lib/i18n/coverage/printers/basic_printer.rb
@@ -15,10 +15,10 @@ module I18n
           puts "I18n Coverage: #{@report[:percentage_used].round(2)}% of the keys used"
           puts "#{@report[:key_count]} keys found in yml files, #{@report[:used_key_count]} keys used during the tests"
 
-          if @report[:unused_keys]
-            puts 'Unused keys:'
-            @report[:unused_keys].map { |k| puts "  #{k}" }
-          end
+          return unless @report[:unused_keys]
+
+          puts 'Unused keys:'
+          @report[:unused_keys].map { |k| puts "  #{k}" }
         end
       end
     end

--- a/lib/i18n/coverage/printers/basic_printer.rb
+++ b/lib/i18n/coverage/printers/basic_printer.rb
@@ -1,0 +1,26 @@
+module I18n
+  module Coverage
+    module Printers
+      class BasicPrinter
+        def self.print(report)
+          new(report).print
+        end
+
+        def initialize(report)
+          @report = report
+        end
+
+        def print
+          puts ""
+          puts "I18n Coverage: #{@report[:percentage_used].round(2)}% of the keys used"
+          puts "#{@report[:key_count]} keys found in yml files, #{@report[:used_key_count]} keys used during the tests"
+
+          if @report[:unused_keys]
+            puts "Unused keys:"
+            @report[:unused_keys].map {|k| puts "  #{k}"}
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/i18n/coverage/printers/basic_printer.rb
+++ b/lib/i18n/coverage/printers/basic_printer.rb
@@ -11,13 +11,13 @@ module I18n
         end
 
         def print
-          puts ""
+          puts ''
           puts "I18n Coverage: #{@report[:percentage_used].round(2)}% of the keys used"
           puts "#{@report[:key_count]} keys found in yml files, #{@report[:used_key_count]} keys used during the tests"
 
           if @report[:unused_keys]
-            puts "Unused keys:"
-            @report[:unused_keys].map {|k| puts "  #{k}"}
+            puts 'Unused keys:'
+            @report[:unused_keys].map { |k| puts "  #{k}" }
           end
         end
       end

--- a/lib/i18n/coverage/printers/file_printer.rb
+++ b/lib/i18n/coverage/printers/file_printer.rb
@@ -1,0 +1,33 @@
+module I18n
+  module Coverage
+    module Printers
+      class FilePrinter
+        REPORT_PATH = "coverage/i18n.json"
+
+        def self.print(report)
+          new(report).print
+        end
+
+        def initialize(report)
+          @report = report
+        end
+
+        def print
+          write_report
+          print_message
+        end
+
+        def write_report
+          FileUtils.mkdir_p(File.dirname(REPORT_PATH))
+          File.write(REPORT_PATH, JSON.pretty_generate(@report))
+        end
+
+        def print_message
+          puts "Coverage report generated for I18n to #{REPORT_PATH}. " \
+            "#{@report[:used_key_count]} / #{@report[:key_count]} keys " \
+            "(#{@report[:percentage_used].round(2)}%) covered."
+        end
+      end
+    end
+  end
+end

--- a/lib/i18n/coverage/printers/file_printer.rb
+++ b/lib/i18n/coverage/printers/file_printer.rb
@@ -2,7 +2,7 @@ module I18n
   module Coverage
     module Printers
       class FilePrinter
-        REPORT_PATH = "coverage/i18n.json"
+        REPORT_PATH = 'coverage/i18n.json'.freeze
 
         def self.print(report)
           new(report).print

--- a/lib/i18n/coverage/reporter.rb
+++ b/lib/i18n/coverage/reporter.rb
@@ -10,29 +10,38 @@ module I18n
 
       def initialize(locale: 'en', locale_dir_path: 'config/locales')
         @existing_keys = KeyLister.list_keys(locale: locale, locale_dir_path: locale_dir_path)
-        @used_keys = KeyLogger.stored_keys
-        @percentage_used = (@used_keys.count.to_f / @existing_keys.count.to_f) * 100
-        @unused_keys = @existing_keys - @used_keys
+        @stored_keys = KeyLogger.stored_keys
       end
 
       def report
         puts ""
-        puts "I18n Coverage: #{@percentage_used.round(2)}% of the keys used"
-        puts "#{@existing_keys.count} keys found in yml file, #{@used_keys.count} keys used during the tests"
+        puts "I18n Coverage: #{hash_report[:percentage_used].round(2)}% of the keys used"
+        puts "#{hash_report[:key_count]} keys found in yml file, #{hash_report[:used_key_count]} keys used during the tests"
 
-        if @unused_keys
+        if hash_report[:unused_keys]
           puts "Unused keys:"
-          @unused_keys.map {|k| puts "  #{k}"}
+          hash_report[:unused_keys].map {|k| puts "  #{k}"}
         end
       end
 
       def hash_report
+        used_keys = @existing_keys - unused_keys
+        percentage_used = (used_keys.count.to_f / @existing_keys.count) * 100
+
         {
           key_count: @existing_keys.count,
-          used_key_count: @used_keys.count,
-          percentage_used: @percentage_used,
-          unused_keys: @unused_keys
+          used_key_count: used_keys.count,
+          percentage_used: percentage_used,
+          unused_keys: unused_keys.to_a
         }
+      end
+
+      private
+
+      def unused_keys
+        @unused_keys ||= @existing_keys.reject do |key|
+          @stored_keys.any? { |stored_key| key.start_with?(stored_key.to_s) }
+        end
       end
     end
   end

--- a/lib/i18n/coverage/reporter.rb
+++ b/lib/i18n/coverage/reporter.rb
@@ -14,14 +14,7 @@ module I18n
       end
 
       def report
-        puts ""
-        puts "I18n Coverage: #{hash_report[:percentage_used].round(2)}% of the keys used"
-        puts "#{hash_report[:key_count]} keys found in yml file, #{hash_report[:used_key_count]} keys used during the tests"
-
-        if hash_report[:unused_keys]
-          puts "Unused keys:"
-          hash_report[:unused_keys].map {|k| puts "  #{k}"}
-        end
+        I18n::Coverage.config.printer.print(hash_report)
       end
 
       def hash_report

--- a/lib/i18n/coverage/reporter.rb
+++ b/lib/i18n/coverage/reporter.rb
@@ -4,12 +4,12 @@ require 'i18n/coverage/key_logger'
 module I18n
   module Coverage
     class Reporter
-      def self.report(locale: 'en', locale_dir_path: 'config/locales')
-        Reporter.new(locale: locale, locale_dir_path: locale_dir_path).report
+      def self.report
+        Reporter.new.report
       end
 
-      def initialize(locale: 'en', locale_dir_path: 'config/locales')
-        @existing_keys = KeyLister.list_keys(locale: locale, locale_dir_path: locale_dir_path)
+      def initialize
+        @existing_keys = KeyLister.list_keys
         @stored_keys = KeyLogger.stored_keys
       end
 

--- a/lib/i18n/coverage/version.rb
+++ b/lib/i18n/coverage/version.rb
@@ -1,5 +1,5 @@
 module I18n
   module Coverage
-    VERSION = "0.1.1"
+    VERSION = '0.1.1'.freeze
   end
 end

--- a/spec/fixtures/multiple/error.yml
+++ b/spec/fixtures/multiple/error.yml
@@ -1,0 +1,3 @@
+---
+en:
+  error: "Oups, something wrong happened"

--- a/spec/fixtures/multiple/home.yml
+++ b/spec/fixtures/multiple/home.yml
@@ -1,0 +1,5 @@
+---
+en:
+  home:
+    title: "Hello"
+    desc: "Welcome here %{username}"

--- a/spec/fixtures/simple/es.yml
+++ b/spec/fixtures/simple/es.yml
@@ -1,0 +1,2 @@
+es:
+  other_key: "Other value"

--- a/spec/i18n/backend/key_logger_spec.rb
+++ b/spec/i18n/backend/key_logger_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe I18n::Backend::KeyLogger do
 
   before do
     # Ok, that could be better with mocking/dummy classes but at least it tests in real conditions
-    I18n::Backend::Simple.send(:include, I18n::Backend::KeyLogger)
-    I18n.backend.store_translations(:en, :some_key => 'Some key in :en')
+    I18n::Backend::Simple.include described_class
+    I18n.backend.store_translations(:en, some_key: 'Some key in :en')
   end
 
   it 'stores the keys used when translating in a I18n::Coverage::KeyLogger' do

--- a/spec/i18n/backend/key_logger_spec.rb
+++ b/spec/i18n/backend/key_logger_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe I18n::Backend::KeyLogger do
   end
 
   it 'stores the keys used when translating in a I18n::Coverage::KeyLogger' do
-    localized = I18n.translate('some_key')
+    I18n.translate('some_key')
     expect(key_logger.stored_keys).to include('some_key')
   end
 

--- a/spec/i18n/coverage/key_lister_spec.rb
+++ b/spec/i18n/coverage/key_lister_spec.rb
@@ -1,9 +1,9 @@
 require 'i18n/coverage/key_lister'
 
 RSpec.describe I18n::Coverage::KeyLister do
-  let(:subject) { I18n::Coverage::KeyLister }
+  let(:subject) { described_class }
 
-  context '.list_keys' do
+  describe '.list_keys' do
     it 'reads all keys in an English locale file' do
       expect(subject.list_keys).to contain_exactly('home.title', 'home.desc', 'error')
     end

--- a/spec/i18n/coverage/key_lister_spec.rb
+++ b/spec/i18n/coverage/key_lister_spec.rb
@@ -4,15 +4,16 @@ RSpec.describe I18n::Coverage::KeyLister do
   let(:subject) { I18n::Coverage::KeyLister }
 
   context '.list_keys' do
-    it 'reads all keys from a locale file' do
+    it 'reads all keys in an English locale file' do
       expect(subject.list_keys(locale_dir_path: 'spec/fixtures/simple')).to contain_exactly('home.title', 'home.desc', 'error')
     end
 
-    it 'uses by default "config/locales/en.yml"' do
-      allow(File).to receive(:open).and_return("---\nen:\n  test: '1'")
+    it 'reads all keys in a specified locale file' do
+      expect(subject.list_keys(locale: 'es', locale_dir_path: 'spec/fixtures/simple')).to contain_exactly('other_key')
+    end
 
-      subject.list_keys
-      expect(File).to have_received(:open).with(File.expand_path('config/locales/en.yml'))
+    it 'reads all keys split across locale files' do
+      expect(subject.list_keys(locale_dir_path: 'spec/fixtures/multiple')).to contain_exactly('home.title', 'home.desc', 'error')
     end
 
     it 'does not take into account the keys used for pluralization' do

--- a/spec/i18n/coverage/key_lister_spec.rb
+++ b/spec/i18n/coverage/key_lister_spec.rb
@@ -5,19 +5,21 @@ RSpec.describe I18n::Coverage::KeyLister do
 
   context '.list_keys' do
     it 'reads all keys in an English locale file' do
-      expect(subject.list_keys(locale_dir_path: 'spec/fixtures/simple')).to contain_exactly('home.title', 'home.desc', 'error')
+      expect(subject.list_keys).to contain_exactly('home.title', 'home.desc', 'error')
     end
 
     it 'reads all keys in a specified locale file' do
-      expect(subject.list_keys(locale: 'es', locale_dir_path: 'spec/fixtures/simple')).to contain_exactly('other_key')
+      I18n::Coverage.config.locale = 'es'
+      expect(subject.list_keys).to contain_exactly('other_key')
     end
 
     it 'reads all keys split across locale files' do
-      expect(subject.list_keys(locale_dir_path: 'spec/fixtures/multiple')).to contain_exactly('home.title', 'home.desc', 'error')
+      expect(subject.list_keys).to contain_exactly('home.title', 'home.desc', 'error')
     end
 
     it 'does not take into account the keys used for pluralization' do
-      expect(subject.list_keys(locale_dir_path: 'spec/fixtures/plurals')).to contain_exactly('simple', 'pluralized')
+      I18n::Coverage.config.locale_dir_path = 'spec/fixtures/plurals'
+      expect(subject.list_keys).to contain_exactly('simple', 'pluralized')
     end
   end
 end

--- a/spec/i18n/coverage/key_lister_spec.rb
+++ b/spec/i18n/coverage/key_lister_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe I18n::Coverage::KeyLister do
     it 'reads all keys from a locale file' do
       expect(subject.list_keys(locale_dir_path: 'spec/fixtures/simple')).to contain_exactly('home.title', 'home.desc', 'error')
     end
-   
+
     it 'uses by default "config/locales/en.yml"' do
       allow(File).to receive(:open).and_return("---\nen:\n  test: '1'")
 

--- a/spec/i18n/coverage/key_logger_spec.rb
+++ b/spec/i18n/coverage/key_logger_spec.rb
@@ -1,7 +1,7 @@
 require 'i18n/coverage/key_logger'
 
 RSpec.describe I18n::Coverage::KeyLogger do
-  let(:subject) { I18n::Coverage::KeyLogger }
+  let(:subject) { described_class }
 
   it 'stores keys with "store_key" and provides the ones stored with "stored_keys"' do
     subject.store_key('Ho hi :)')

--- a/spec/i18n/coverage/key_logger_spec.rb
+++ b/spec/i18n/coverage/key_logger_spec.rb
@@ -13,13 +13,13 @@ RSpec.describe I18n::Coverage::KeyLogger do
     subject.store_key('Ho hi :)')
     subject.store_key('Ho hi :)')
 
-    expect(subject.stored_keys.length).to eq(1)    
+    expect(subject.stored_keys.length).to eq(1)
   end
 
   it 'shares keys across all instances' do
     instance1 = subject.new
     instance2 = subject.new
-    
+
     instance1.store_key('key1')
     instance1.store_key('key2')
 

--- a/spec/i18n/coverage/key_logger_spec.rb
+++ b/spec/i18n/coverage/key_logger_spec.rb
@@ -16,16 +16,6 @@ RSpec.describe I18n::Coverage::KeyLogger do
     expect(subject.stored_keys.length).to eq(1)
   end
 
-  it 'shares keys across all instances' do
-    instance1 = subject.new
-    instance2 = subject.new
-
-    instance1.store_key('key1')
-    instance1.store_key('key2')
-
-    expect(instance2.stored_keys).to eq(instance1.stored_keys)
-  end
-
   describe '.clear_keys' do
     it 'empties the stored keys' do
       subject.store_key('plop')

--- a/spec/i18n/coverage/printers/basic_printer_spec.rb
+++ b/spec/i18n/coverage/printers/basic_printer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe I18n::Coverage::Printers::BasicPrinter do
         key_count: 4,
         used_key_count: 2,
         percentage_used: 50.0,
-        unused_keys: ["a", "b"]
+        unused_keys: %w[a b]
       }
 
       expect { described_class.print(hash_report) }.to output([

--- a/spec/i18n/coverage/printers/basic_printer_spec.rb
+++ b/spec/i18n/coverage/printers/basic_printer_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe I18n::Coverage::Printers::BasicPrinter do
+  describe '.print' do
+    it 'outputs a summary of the I18n keys used during tests' do
+      hash_report = {
+        key_count: 4,
+        used_key_count: 2,
+        percentage_used: 50.0,
+        unused_keys: ["a", "b"]
+      }
+
+      expect { described_class.print(hash_report) }.to output([
+        '',
+        'I18n Coverage: 50.0% of the keys used',
+        '4 keys found in yml files, 2 keys used during the tests',
+        'Unused keys:',
+        '  a',
+        '  b',
+        ''
+      ].join("\n")).to_stdout
+    end
+  end
+end

--- a/spec/i18n/coverage/printers/file_printer_spec.rb
+++ b/spec/i18n/coverage/printers/file_printer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe I18n::Coverage::Printers::FilePrinter do
         key_count: 4,
         used_key_count: 2,
         percentage_used: 50.0,
-        unused_keys: ["a", "b"]
+        unused_keys: %w[a b]
       }
     end
 

--- a/spec/i18n/coverage/printers/file_printer_spec.rb
+++ b/spec/i18n/coverage/printers/file_printer_spec.rb
@@ -1,0 +1,38 @@
+require 'i18n/coverage/printers/file_printer'
+
+RSpec.describe I18n::Coverage::Printers::FilePrinter do
+  describe '.print' do
+    let(:hash_report) do
+      {
+        key_count: 4,
+        used_key_count: 2,
+        percentage_used: 50.0,
+        unused_keys: ["a", "b"]
+      }
+    end
+
+    before do
+      allow(FileUtils).to receive(:mkdir_p)
+      allow(File).to receive(:write)
+    end
+
+    it 'outputs a SimpleCov-style summary of I18n coverage' do
+      expect { described_class.print(hash_report) }.to output(
+        "Coverage report generated for I18n to coverage/i18n.json. 2 / 4 keys (50.0%) covered.\n"
+      ).to_stdout
+    end
+
+    it 'writes the coverage report to a JSON file' do
+      expect(FileUtils).to receive(:mkdir_p).with(
+        File.dirname(I18n::Coverage::Printers::FilePrinter::REPORT_PATH)
+      )
+
+      expect(File).to receive(:write).with(
+        I18n::Coverage::Printers::FilePrinter::REPORT_PATH,
+        JSON.pretty_generate(hash_report)
+      )
+
+      described_class.print(hash_report)
+    end
+  end
+end

--- a/spec/i18n/coverage/reporter_spec.rb
+++ b/spec/i18n/coverage/reporter_spec.rb
@@ -5,9 +5,7 @@ RSpec.describe I18n::Coverage::Reporter do
 
   context '.report' do
     it 'outputs a summary of the I18n keys used during tests' do
-      expect {
-        subject.report(locale_dir_path: 'spec/fixtures/simple')
-      }.to output([
+      expect { subject.report }.to output([
         '',
         'I18n Coverage: 0.0% of the keys used',
         '3 keys found in yml file, 0 keys used during the tests',
@@ -22,7 +20,7 @@ RSpec.describe I18n::Coverage::Reporter do
 
   context '#hash_report' do
     it 'provides the same data as .report but in a machine-readable way' do
-      report = subject.new(locale_dir_path: 'spec/fixtures/simple').hash_report
+      report = subject.new.hash_report
 
       expect(report[:key_count]).to eq(3)
       expect(report[:used_key_count]).to eq(0)

--- a/spec/i18n/coverage/reporter_spec.rb
+++ b/spec/i18n/coverage/reporter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe I18n::Coverage::Reporter do
       expect { subject.report }.to output([
         '',
         'I18n Coverage: 0.0% of the keys used',
-        '3 keys found in yml file, 0 keys used during the tests',
+        '3 keys found in yml files, 0 keys used during the tests',
         'Unused keys:',
         '  home.title',
         '  home.desc',

--- a/spec/i18n/coverage/reporter_spec.rb
+++ b/spec/i18n/coverage/reporter_spec.rb
@@ -29,5 +29,15 @@ RSpec.describe I18n::Coverage::Reporter do
       expect(report[:percentage_used]).to eq(0)
       expect(report[:unused_keys]).to contain_exactly('home.title', 'home.desc', 'error')
     end
+
+    it 'supports advanced I18n calls with prefixes' do
+      I18n::Coverage::KeyLogger.store_key('home')
+      report = subject.new.hash_report
+
+      expect(report[:key_count]).to eq(3)
+      expect(report[:used_key_count]).to eq(2)
+      expect(report[:percentage_used]).to eq(2/3.to_f * 100)
+      expect(report[:unused_keys]).to contain_exactly('error')
+    end
   end
 end

--- a/spec/i18n/coverage/reporter_spec.rb
+++ b/spec/i18n/coverage/reporter_spec.rb
@@ -1,11 +1,11 @@
 require 'i18n/coverage/reporter'
 
 RSpec.describe I18n::Coverage::Reporter do
-  let(:subject) { I18n::Coverage::Reporter }
+  let(:subject) { described_class }
 
-  context '.report' do
+  describe '.report' do
     it 'outputs a summary of the I18n keys used during tests' do
-      expect { subject.report }.to output([
+      expect { described_class.report }.to output([
         '',
         'I18n Coverage: 0.0% of the keys used',
         '3 keys found in yml files, 0 keys used during the tests',
@@ -18,7 +18,7 @@ RSpec.describe I18n::Coverage::Reporter do
     end
   end
 
-  context '#hash_report' do
+  describe '#hash_report' do
     it 'provides the same data as .report but in a machine-readable way' do
       report = subject.new.hash_report
 
@@ -34,7 +34,7 @@ RSpec.describe I18n::Coverage::Reporter do
 
       expect(report[:key_count]).to eq(3)
       expect(report[:used_key_count]).to eq(2)
-      expect(report[:percentage_used]).to eq(2/3.to_f * 100)
+      expect(report[:percentage_used]).to eq(2 / 3.to_f * 100)
       expect(report[:unused_keys]).to contain_exactly('error')
     end
   end

--- a/spec/i18n/coverage_spec.rb
+++ b/spec/i18n/coverage_spec.rb
@@ -2,4 +2,12 @@ RSpec.describe I18n::Coverage do
   it "has a version number" do
     expect(I18n::Coverage::VERSION).not_to be nil
   end
+
+  describe ".start" do
+    it "instruments I18n and prints a report at exit" do
+      expect(I18n::Backend::Simple).to receive(:include).with(I18n::Backend::KeyLogger)
+      expect(subject).to receive(:at_exit)
+      subject.start
+    end
+  end
 end

--- a/spec/i18n/coverage_spec.rb
+++ b/spec/i18n/coverage_spec.rb
@@ -1,10 +1,10 @@
 RSpec.describe I18n::Coverage do
-  it "has a version number" do
+  it 'has a version number' do
     expect(I18n::Coverage::VERSION).not_to be nil
   end
 
-  describe ".start" do
-    it "instruments I18n and prints a report at exit" do
+  describe '.start' do
+    it 'instruments I18n and prints a report at exit' do
       expect(I18n::Backend::Simple).to receive(:include).with(I18n::Backend::KeyLogger)
       expect(subject).to receive(:at_exit)
       subject.start

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,8 +21,8 @@ RSpec.configure do |config|
   config.before do
     I18n::Coverage::KeyLogger.clear_keys
 
-    I18n::Coverage.configure do |config|
-      config.locale_dir_path = 'spec/fixtures/simple'
+    I18n::Coverage.configure do |cov_config|
+      cov_config.locale_dir_path = 'spec/fixtures/simple'
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,13 +3,13 @@ SimpleCov.start do
   add_filter '/spec/'
 end
 
-require "i18n"
-require "bundler/setup"
-require "i18n/coverage"
+require 'i18n'
+require 'bundler/setup'
+require 'i18n/coverage'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
+  config.example_status_persistence_file_path = '.rspec_status'
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
@@ -18,7 +18,7 @@ RSpec.configure do |config|
     c.syntax = :expect
   end
 
-  config.before(:each) do
+  config.before do
     I18n::Coverage::KeyLogger.clear_keys
 
     I18n::Coverage.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,10 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do
-    require 'i18n/coverage/key_logger'
     I18n::Coverage::KeyLogger.clear_keys
+
+    I18n::Coverage.configure do |config|
+      config.locale_dir_path = 'spec/fixtures/simple'
+    end
   end
 end


### PR DESCRIPTION
This adds support for a few new features:

- Multiple YAML files (when a repo has lots of translations)
- Partial matching (to cope with advanced usages of I18n)
- Configurable output (so we can enforce coverage in CI)
- Adds RuboCop (so it's easier to be consistent in future)

Please see the commits for the steps to get to the final output.

Many of these changes are based on a [similar piece of code](https://github.com/alphagov/content-publisher/blob/master/spec/support/i18n_cov.rb), 
which I wanted to turn into a gem. Rather than making a new 
gem, I hope this will be an acceptable improvement for this 
one, so that all the knowledge/functionality is in one place.