### PR TITLE
Relax coverage criteria

### DIFF
--- a/lib/i18n/backend/key_logger.rb
+++ b/lib/i18n/backend/key_logger.rb
@@ -4,6 +4,7 @@ module I18n
   module Backend
     module KeyLogger
       def lookup(locale, key, scope = [], options = {})
+        key = (Array(scope || []) + [key]).compact.join('.')
         I18n::Coverage::KeyLogger.store_key(key)
         super
       end

--- a/lib/i18n/backend/key_logger.rb
+++ b/lib/i18n/backend/key_logger.rb
@@ -3,8 +3,8 @@ require 'i18n/coverage/key_logger'
 module I18n
   module Backend
     module KeyLogger
-      def translate(*args)
-        I18n::Coverage::KeyLogger.store_key(args[1])
+      def lookup(locale, key, scope = [], options = {})
+        I18n::Coverage::KeyLogger.store_key(key)
         super
       end
     end

--- a/spec/i18n/backend/key_logger_spec.rb
+++ b/spec/i18n/backend/key_logger_spec.rb
@@ -17,4 +17,9 @@ RSpec.describe I18n::Backend::KeyLogger do
   it 'does not impact the translation process' do
     expect(I18n.translate('some_key')).to eq('Some key in :en')
   end
+
+  it 'stores keys these are looked up but are not strictly translated' do
+    I18n.exists?('some_key')
+    expect(key_logger.stored_keys).to include('some_key')
+  end
 end

--- a/spec/i18n/backend/key_logger_spec.rb
+++ b/spec/i18n/backend/key_logger_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe I18n::Backend::KeyLogger do
     expect(I18n.translate('some_key')).to eq('Some key in :en')
   end
 
+  it 'stores keys used with an optional scope argument' do
+    I18n.translate('some_key', scope: %i[some_outer_prefix some_prefix])
+    expect(key_logger.stored_keys).to include('some_outer_prefix.some_prefix.some_key')
+  end
+
   it 'stores keys these are looked up but are not strictly translated' do
     I18n.exists?('some_key')
     expect(key_logger.stored_keys).to include('some_key')


### PR DESCRIPTION
This adds support for a couple of unusual ways of calling I18n that weren't previously counted as part of the coverage. Please see the commits for more details.