### PR TITLE
Ensure scoped translations are not affected when translating

### DIFF
--- a/lib/i18n/backend/key_logger.rb
+++ b/lib/i18n/backend/key_logger.rb
@@ -4,8 +4,8 @@ module I18n
   module Backend
     module KeyLogger
       def lookup(locale, key, scope = [], options = {})
-        key = (Array(scope || []) + [key]).compact.join('.')
-        I18n::Coverage::KeyLogger.store_key(key)
+        full_key = (Array(scope || []) + [key]).compact.join('.')
+        I18n::Coverage::KeyLogger.store_key(full_key)
         super
       end
     end

--- a/spec/i18n/backend/key_logger_spec.rb
+++ b/spec/i18n/backend/key_logger_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe I18n::Backend::KeyLogger do
     # Ok, that could be better with mocking/dummy classes but at least it tests in real conditions
     I18n::Backend::Simple.include described_class
     I18n.backend.store_translations(:en, some_key: 'Some key in :en')
+    I18n.backend.store_translations(:en, some_outer_prefix: { some_prefix: { some_key: 'Scoped translation' } })
   end
 
   it 'stores the keys used when translating in a I18n::Coverage::KeyLogger' do
@@ -16,6 +17,7 @@ RSpec.describe I18n::Backend::KeyLogger do
 
   it 'does not impact the translation process' do
     expect(I18n.translate('some_key')).to eq('Some key in :en')
+    expect(I18n.translate('some_key', scope: %i[some_outer_prefix some_prefix])).to eq('Scoped translation')
   end
 
   it 'stores keys used with an optional scope argument' do


### PR DESCRIPTION
While setting up our project at work to use this, I encountered issues with scoped translation keys were being modified while stored.